### PR TITLE
Fix string lexer

### DIFF
--- a/ritchie.l
+++ b/ritchie.l
@@ -60,7 +60,7 @@ numeral       [0-9]
 alphanumeric  {alphabetic}|{numeral}
 integer       {numeral}+
 float         {numeral}+"."{numeral}*
-string        \"(\\.|[^"])*\"
+string        \"(\\.|[^\\"])*\"
 identifier    {alphabetic}{alphanumeric}*
 comment       \/\/.*
 


### PR DESCRIPTION
Current compiler cannot parse this file:

```
print "\\" + "foo"
```

I fix it.